### PR TITLE
Support unregistering an action.

### DIFF
--- a/lib/traffic_jam/configuration.rb
+++ b/lib/traffic_jam/configuration.rb
@@ -14,6 +14,12 @@ module TrafficJam
       @limits[action.to_sym] = { max: max, period: period }
     end
 
+    def unregister(action)
+      if @limits
+        @limits.delete(action.to_sym)
+      end
+    end
+
     def max(action)
       limits(action)[:max]
     end

--- a/spec/traffic_jam_configuration_spec.rb
+++ b/spec/traffic_jam_configuration_spec.rb
@@ -25,4 +25,16 @@ describe TrafficJam do
       assert_equal 60, config.period(:test)
     end
   end
+
+  describe '.unregister' do
+    it "should remove unregistered actions" do
+      config.register(:test_2, 1, 1)
+      assert_equal({max: 1, period: 1}, config.limits(:test_2))
+
+      config.unregister(:test_2)
+      assert_raises(TrafficJam::LimitNotFound) do
+        config.limits(:test_2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Particularly useful for testing.